### PR TITLE
Prefer libc::time_t over std::*::time_t

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -1,6 +1,4 @@
-use std::os::unix::raw::time_t;
-
-use ::libc::{c_void,c_int,c_char,c_uchar,c_ulong,size_t};
+use ::libc::{c_void,c_int,c_char,c_uchar,c_ulong,size_t,time_t};
 
 // TODO: should be *const c_char
 pub const GP_MIME_WAV:       &'static [u8] = b"audio/wav\0";

--- a/src/filesys.rs
+++ b/src/filesys.rs
@@ -1,8 +1,6 @@
 // exports from gphoto2-filesys.h
 
-use std::os::unix::raw::time_t;
-
-use ::libc::{c_int,c_char};
+use ::libc::{c_int,c_char,time_t};
 
 #[repr(C)]
 pub struct CameraStorageInformation {


### PR DESCRIPTION
This already links to libc which is responsible for the correct definitions
rather than libstd itself.
