### PR TITLE
Add missing exports from gphoto2-setting.h

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub use port::*;
 pub use result::*;
 pub use version::*;
 pub use widget::*;
+pub use setting::*;
 
 mod abilities;
 mod camera;
@@ -23,3 +24,4 @@ mod port;
 mod result;
 mod version;
 mod widget;
+mod setting;

--- a/src/setting.rs
+++ b/src/setting.rs
@@ -1,0 +1,8 @@
+// exports from gphoto2-setting.h
+
+use libc::{c_int, c_char};
+
+extern "C" {
+    pub fn gp_setting_set(id: *const c_char, key: *const c_char, value: *const c_char) -> c_int;
+    pub fn gp_setting_get(id: *const c_char, key: *const c_char, value: *const c_char) -> c_int;
+}


### PR DESCRIPTION
Useful in particular when autodetect needs a bit of help (like in the case of my camera, I need to explicitly give gphoto the ptpip port when accessing over wifi).